### PR TITLE
Updating tensorflow to 2.3 and Flask to 2.0

### DIFF
--- a/services/risk-assessment/requirements.txt
+++ b/services/risk-assessment/requirements.txt
@@ -1,7 +1,7 @@
-tensorflow==2.1.*
-boto3==1.14.*
-pillow==7.2.*
+tensorflow==2.3.*
+boto3==1.17.*
+pillow==8.0.*
 cloudevents==1.2.*
 mysql-connector-python==8.0.*
-Flask==1.1.*
+Flask==2.0.*
 flask-cors==3.0.*

--- a/services/risk-assessment/risk-assessment.py
+++ b/services/risk-assessment/risk-assessment.py
@@ -127,12 +127,15 @@ def extract_data(data):
     return data_out
 
 def load_image(bucket_name, img_path):
+    local_path = "/tmp/%s"% (img_path,)
     logging.info('load_image')
     logging.info(bucket_name)
     logging.info(img_path)
-    obj = s3client.get_object(Bucket=bucket_name, Key=img_path)
-    img_stream = io.BytesIO(obj['Body'].read())
-    img = tf.keras.preprocessing.image.load_img(img_stream, target_size=(150, 150))
+    logging.info(local_path)
+    
+    s3client.download_file(bucket_name, img_path, local_path)
+    
+    img = tf.keras.preprocessing.image.load_img(local_path, target_size=(150, 150))
     img_tensor = tf.keras.preprocessing.image.img_to_array(img)                    # (height, width, channels)
     img_tensor = np.expand_dims(img_tensor, axis=0)         # (1, height, width, channels), add a dimension because the model expects this shape: (batch_size, height, width, channels)
     img_tensor /= 255.                                      # imshow expects values in the range [0, 1]


### PR DESCRIPTION
This aligns the versions of tf and Flask to what's in Open Data Hub so that we can use the model created in the notebook in the running image.